### PR TITLE
docs: new VScode 1.14 default protocol changed.

### DIFF
--- a/docs/source/zh-cn/core/development.md
+++ b/docs/source/zh-cn/core/development.md
@@ -332,6 +332,7 @@ exports.proxyworker = {
       "runtimeArgs": [
         "run", "dev", "--", "--debug"
       ],
+      "protocol": "legacy",
       "port": 5858
     },
     {
@@ -366,8 +367,10 @@ exports.proxyworker = {
 
 当且仅当你的 Node.js 版本大于 7.x 时，可以使用 [Inspector Protocol] 进行调试。
 
+VScode升级1.14后，默认protocol由 Legacy 变为了 Inspector，如果仍需使用Legacy, 要手动指定。详情参考 https://github.com/Microsoft/vscode/issues/30629#issuecomment-315196813
+
 在上面的调试配置中需要修改一些参数来开启新协议:
-- `Launch Egg` 调整参数 `"runtimeArgs": ["run", "debug"]`
+- `Launch Egg` 调整参数 `"runtimeArgs": ["run", "debug"]`、`"protocol": "inspector"`
 - `Attach Worker` 添加参数 `"protocol": "inspector"`
 
 此外，如果使用新协议还可以通过 chrome devtools 进行调试, 调试地址：


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)


##### Description of change
change docs:  [https://eggjs.org/zh-cn/core/development.html#使用-vscode-进行调试](https://eggjs.org/zh-cn/core/development.html#使用-vscode-进行调试)

related issue: https://github.com/eggjs/egg/issues/1206
